### PR TITLE
Update metadata.json to support gnome 48

### DIFF
--- a/gestureImprovements@gestures/metadata.json
+++ b/gestureImprovements@gestures/metadata.json
@@ -5,7 +5,8 @@
   "settings-schema": "org.gnome.shell.extensions.gestureImprovements",
   "shell-version": [
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "url": "https://github.com/harshadgavali/gnome-gesture-improvements",
   "uuid": "gestureImprovements@gestures",


### PR DESCRIPTION
Thanks for maintaining this extension! I can't live without it.

I just upgraded to Fedora 42 which ships Gnome 48, and it seems to just work when rebuilding this extension with 48 in the list of supported versions.